### PR TITLE
gas improvements with unchecked increment in for loops

### DIFF
--- a/contracts/MultiRoundCheckout.sol
+++ b/contracts/MultiRoundCheckout.sol
@@ -52,9 +52,13 @@ contract MultiRoundCheckout is
         // possible previous balance + msg.value
         uint256 initialBalance = address(this).balance;
 
-        for (uint i = 0; i < rounds.length; i++) {
+        for (uint256 i = 0; i < rounds.length;) {
             IVotable round = IVotable(payable(rounds[i]));
             round.vote{value: amounts[i]}(votes[i]);
+
+            unchecked {
+                ++i;
+            }
         }
 
         if (address(this).balance != initialBalance - msg.value) {
@@ -106,10 +110,14 @@ contract MultiRoundCheckout is
 
         IERC20Upgradeable(token).transferFrom(msg.sender, address(this), totalAmount);
 
-        for (uint i = 0; i < rounds.length; i++) {
+        for (uint256 i = 0; i < rounds.length;) {
             IVotable round = IVotable(rounds[i]);
             IERC20Upgradeable(token).approve(address(round.votingStrategy()), amounts[i]);
             round.vote(votes[i]);
+
+            unchecked {
+                ++i;
+            }
         }
 
         if (IERC20Upgradeable(token).balanceOf(address(this)) != initialBalance) {
@@ -162,10 +170,14 @@ contract MultiRoundCheckout is
 
         IERC20Upgradeable(token).transferFrom(msg.sender, address(this), totalAmount);
 
-        for (uint i = 0; i < rounds.length; i++) {
+        for (uint256 i = 0; i < rounds.length;) {
             IVotable round = IVotable(rounds[i]);
             IERC20Upgradeable(token).approve(address(round.votingStrategy()), amounts[i]);
             round.vote(votes[i]);
+
+            unchecked {
+                ++i;
+            }
         }
 
         if (IERC20Upgradeable(token).balanceOf(address(this)) != initialBalance) {


### PR DESCRIPTION
review after #7 

testVoteERC20Permit
from 543082
to   542956

testVotesPassing
from 432985
to   432796

testVoteDAIPermit
from 550374
to   550248

We tested that removing the initialization of `i` from `for` loops doesn't change
anything in gas consumption.
